### PR TITLE
Memory leak in CreatorReader.cpp

### DIFF
--- a/creator_project/packages/creator-luacpp-support/reader/CreatorReader.cpp
+++ b/creator_project/packages/creator-luacpp-support/reader/CreatorReader.cpp
@@ -58,6 +58,7 @@ CreatorReader* CreatorReader::createWithFilename(const std::string& filename)
         reader->autorelease();
         return reader;
     }
+    delete reader;
     return nullptr;
 }
 


### PR DESCRIPTION
If the init returned false, the create static method would be leaking the object.